### PR TITLE
Upgrade to experimental NextAuth v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "eventsource-parser": "^1.0.0",
         "mongoose": "^6.9.2",
         "next": "latest",
-        "next-auth": "^4.20.1",
+        "next-auth": "^0.0.0-manual.d0952342",
         "openai": "^3.2.1",
         "react": "latest",
         "react-dom": "latest",
@@ -49,6 +49,27 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.0.0-manual.8fcd46b0",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.0.0-manual.8fcd46b0.tgz",
+      "integrity": "sha512-KuhvZ0hHz6NvMAgAi+su0dJOD0YAiOWGaLswyfGK5RsG/cdhqyyiII9HOTaZbWZAKir0UGYb8SlN+owhV30JXg==",
+      "dependencies": {
+        "@panva/hkdf": "^1.0.4",
+        "cookie": "0.5.0",
+        "jose": "^4.11.1",
+        "oauth4webapi": "^2.0.6",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "nodemailer": {
+          "optional": true
+        }
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -5794,25 +5815,16 @@
       }
     },
     "node_modules/next-auth": {
-      "version": "4.22.3",
-      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.22.3.tgz",
-      "integrity": "sha512-XAgy9xV3J2eJOXrQhmxdjV6MLM29ibm6WtMXc3KY6IPZeApf+SuBuPvlqCUfbu5YsAzlg9WSw6u01dChTfeZOA==",
+      "version": "0.0.0-manual.d0952342",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-0.0.0-manual.d0952342.tgz",
+      "integrity": "sha512-lrluxTz6ik6OcMPkRpX8lbSfJdnxQez9UNrFfjoRIFSoNnHd2Vjg+9R+TDl+Li7VUVhG/bO01bVENABN9ApThw==",
       "dependencies": {
-        "@babel/runtime": "^7.20.13",
-        "@panva/hkdf": "^1.0.2",
-        "cookie": "^0.5.0",
-        "jose": "^4.11.4",
-        "oauth": "^0.9.15",
-        "openid-client": "^5.4.0",
-        "preact": "^10.6.3",
-        "preact-render-to-string": "^5.1.19",
-        "uuid": "^8.3.2"
+        "@auth/core": "experimental"
       },
       "peerDependencies": {
-        "next": "^12.2.5 || ^13",
+        "next": "^13.4.10",
         "nodemailer": "^6.6.5",
-        "react": "^17.0.2 || ^18",
-        "react-dom": "^17.0.2 || ^18"
+        "react": "^18.2.0"
       },
       "peerDependenciesMeta": {
         "nodemailer": {
@@ -5903,10 +5915,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth": {
-      "version": "0.9.15",
-      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
-      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA=="
+    "node_modules/oauth4webapi": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.3.0.tgz",
+      "integrity": "sha512-JGkb5doGrwzVDuHwgrR4nHJayzN4h59VCed6EW8Tql6iHDfZIabCJvg6wtbn5q6pyB2hZruI3b77Nudvq7NmvA==",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5914,14 +5929,6 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
-      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -6014,14 +6021,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/oidc-token-hash": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.0.3.tgz",
-      "integrity": "sha512-IF4PcGgzAr6XXSff26Sk/+P4KZFJVuHAJZj3wgO3vX2bMdNVp/QXTP3P7CEm9V1IdG8lDLY3HhiqpsE/nOwpPw==",
-      "engines": {
-        "node": "^10.13.0 || >=12.0.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -6068,20 +6067,6 @@
       "dependencies": {
         "axios": "^0.26.0",
         "form-data": "^4.0.0"
-      }
-    },
-    "node_modules/openid-client": {
-      "version": "5.4.3",
-      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.4.3.tgz",
-      "integrity": "sha512-sVQOvjsT/sbSfYsQI/9liWQGVZH/Pp3rrtlGEwgk/bbHfrUDZ24DN57lAagIwFtuEu+FM9Ev7r85s8S/yPjimQ==",
-      "dependencies": {
-        "jose": "^4.14.4",
-        "lru-cache": "^6.0.0",
-        "object-hash": "^2.2.0",
-        "oidc-token-hash": "^5.0.3"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/optionator": {
@@ -6239,18 +6224,18 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
     "node_modules/preact": {
-      "version": "10.16.0",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
-      "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
       }
     },
     "node_modules/preact-render-to-string": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
-      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
       "dependencies": {
         "pretty-format": "^3.8.0"
       },
@@ -7594,6 +7579,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "eventsource-parser": "^1.0.0",
     "mongoose": "^6.9.2",
     "next": "latest",
-    "next-auth": "^4.20.1",
+    "next-auth": "^0.0.0-manual.d0952342",
     "openai": "^3.2.1",
     "react": "latest",
     "react-dom": "latest",


### PR DESCRIPTION
### What
As part of the Cue rearchitecture (#10) / App Router migration, we need to upgrade NextAuth (Auth.js) for the below reason.

### Why
NextAuth v4 (current) is not compatible with Edge Functions, which we use for the `/generate` API route. In order to secure this route (#12, #16), we need to tap into the current `session`. This is not possible without a migration.

### Potential pitfalls
- [NextAuth v5 is experimental](https://github.com/nextauthjs/next-auth/pull/7443), so this may lead to some unexpected bugs.
- NextAuth v5 introduces breaking changes, which might affect how the rest of the application is structured, prolonging dev time on the rearchitecture.

### Plan B
Securing the application is absolutely essential and non-negotiable for sharing access to Cue. Ideally, this is not something compromised on, but at the same time, we cannot stall App Router migration that long, as new features will not be built on top of the current production version (Cue v0.4.0), which is using the Pages Router.

Alternatives to this solution:
- Disabling streaming, reverting from Edge Functions, and reverting to GPT-3.5
- Figuring out a way to lock the API route to the application itself, and rejecting any external calls

### Resources
Thankfully, as all of this — App Router, Edge Functions, etc. — is experimental as it is, so the majority of auth-based AI-related applications using Next.js and Vercel are already using an experimental version of NextAuth.
- [Vercel's Next.js AI Chatbot template](https://github.com/vercel-labs/ai-chatbot)