### PR TITLE
Migrate to Vercel KV

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@typeform/embed-react": "^2.19.0",
         "@types/react": "^18.0.38",
+        "@vercel/kv": "^0.2.2",
         "eslint": "8.37.0",
         "eslint-config-next": "latest",
         "eslint-config-standard": "^17.0.0",
@@ -2199,6 +2200,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.21.0",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.21.0.tgz",
+      "integrity": "sha512-c6M+cl0LOgGK/7Gp6ooMkIZ1IDAJs8zFR+REPkoSkAq38o7CWFX5FYwYEqGZ6wJpUGBuEOr/7hTmippXGgL25A==",
+      "dependencies": {
+        "isomorphic-fetch": "^3.0.0"
+      }
+    },
+    "node_modules/@vercel/kv": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@vercel/kv/-/kv-0.2.2.tgz",
+      "integrity": "sha512-mqnQOB6bkp4h5eObxfLNIlhlVqOGSH8cWOlC5pDVWTjX3zL8dETO1ZBl6M74HBmeBjbD5+J7wDJklRigY6UNKw==",
+      "dependencies": {
+        "@upstash/redis": "1.21.0"
+      },
+      "engines": {
+        "node": ">=14.6"
       }
     },
     "node_modules/acorn": {
@@ -5173,6 +5193,15 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
+    "node_modules/isomorphic-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+      "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "whatwg-fetch": "^3.4.1"
+      }
+    },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
@@ -5830,6 +5859,44 @@
         "nodemailer": {
           "optional": true
         }
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-releases": {
@@ -7603,6 +7670,11 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/whatwg-fetch": {
+      "version": "3.6.17",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.17.tgz",
+      "integrity": "sha512-c4ghIvG6th0eudYwKZY5keb81wtFz9/WeAHAoy8+r18kcWlitUIrmGFQ2rWEl4UCKUilD3zCLHOIPheHx5ypRQ=="
     },
     "node_modules/whatwg-url": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@typeform/embed-react": "^2.19.0",
     "@types/react": "^18.0.38",
+    "@vercel/kv": "^0.2.2",
     "eslint": "8.37.0",
     "eslint-config-next": "latest",
     "eslint-config-standard": "^17.0.0",

--- a/src/app/api/hello/route.js
+++ b/src/app/api/hello/route.js
@@ -1,0 +1,13 @@
+import { kv } from '@vercel/kv'
+import { NextResponse } from 'next/server'
+import { getSessionData } from '@/functions/user-management'
+
+export async function GET () {
+  const sessionData = await getSessionData()
+  if (!sessionData) return NextResponse.json({ error: 'You\'re not signed in!' }, { status: 401 })
+  const userData = await kv.get(sessionData.sub)
+  if (!userData) return NextResponse.json({
+    error: 'You\'re singed in but we couldn\'t find your data! Visit the profile page to have it generated.'
+  }, { status: 401 })
+  return NextResponse.json(userData)
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,5 +1,6 @@
 // Next imports
-import { getSessionData } from '@/functions/user-management'
+import { getUser } from '@/functions/user-management'
+import checkAuth from '@/functions/check-auth'
 import { redirect } from 'next/navigation'
 
 // Component imports
@@ -9,9 +10,10 @@ import SignInButton from '@/components/Button/SignInButton'
 import styles from '@/styles/Home.module.scss'
 
 export default async function Home () {
-  const sessionData = await getSessionData()
+  const user = await getUser()
+  const authed = await checkAuth({ user })
 
-  if (sessionData)
+  if (authed)
     redirect('/profile')
 
   return (

--- a/src/functions/check-auth.js
+++ b/src/functions/check-auth.js
@@ -58,4 +58,6 @@ export default async function checkAuth ({ user, inviteCode }) {
 
   if (currentAuthLevel >= 4)
     return true
+
+  return false
 }

--- a/src/functions/invite-management.js
+++ b/src/functions/invite-management.js
@@ -1,5 +1,6 @@
 import connect from '@/functions/db-connect.js'
 import Invite from '@/schemas/invite-schema'
+// TODO: Migrate invites to Vercel KV
 
 export async function validate (inviteCode) {
   const inviteStatus = {}

--- a/src/functions/user-management.js
+++ b/src/functions/user-management.js
@@ -1,9 +1,6 @@
-// Auth.js
 import { auth } from '@/../auth'
-
-// Database imports
-import connect from '@/functions/db-connect.js'
-import User from '@/schemas/user-schema.js'
+import { kv } from '@vercel/kv'
+// TODO: schema validation
 
 export async function getSessionData (authParams) {
   let session
@@ -13,18 +10,13 @@ export async function getSessionData (authParams) {
     session = await auth()
   if (!session) return null
   const sessionData = session.user
-
   return sessionData
 }
 
 export async function getUserData () {
   const sessionData = await getSessionData()
   if (!sessionData) return null
-
-  // Search the database for the user's ID
-  await connect()
-  const userData = await User.findOne({ googleId: sessionData.sub })
-
+  const userData = await kv.get(sessionData.sub)
   return userData
 }
 
@@ -43,13 +35,10 @@ export async function getUser () {
 export async function createUser (properties) {
   const { sessionData, userData } = await getUser()
   if (userData) return null
-
-  await connect()
-  const user = {
-    googleId: sessionData.id,
+  const newUser = await kv.set(sessionData.sub, {
+    googleId: sessionData.sub,
     cues: [],
     invitesRemaining: properties?.invitesRemaining || 1
-  }
-  const newUser = await User.create(user)
+  })
   return newUser
 }

--- a/src/functions/user-management.js
+++ b/src/functions/user-management.js
@@ -1,6 +1,7 @@
 import { auth } from '@/../auth'
 import { kv } from '@vercel/kv'
 // TODO: schema validation
+// TODO: remove authParams once transition to App Router is complete
 
 export async function getSessionData (authParams) {
   let session
@@ -13,19 +14,30 @@ export async function getSessionData (authParams) {
   return sessionData
 }
 
-export async function getUserData () {
-  const sessionData = await getSessionData()
+export async function getUserData (authParams) {
+  let sessionData
+  if (authParams)
+    sessionData = await getSessionData(authParams)
+  else
+    sessionData = await getSessionData()
   if (!sessionData) return null
   const userData = await kv.get(sessionData.sub)
   return userData
 }
 
-export async function getUser () {
-  const sessionData = await getSessionData()
-  let userData = await getUserData()
-  userData = JSON.parse(JSON.stringify(userData))
+export async function getUser (authParams) {
+  let sessionData
+  if (authParams)
+    sessionData = await getSessionData(authParams)
+  else
+    sessionData = await getSessionData()
 
-  // Associate the user's session data with the user's database data and return as one object
+  let userData
+  if (authParams)
+    userData = await getUserData(authParams)
+  else
+    userData = await getUserData()
+
   return {
     sessionData: sessionData || null,
     userData: userData || null

--- a/src/pages/cue/index.js
+++ b/src/pages/cue/index.js
@@ -1,7 +1,9 @@
 // Next imports
 import { useState, useEffect } from 'react'
 import { useSession } from 'next-auth/react'
-import { getSessionData } from '@/functions/user-management'
+import { getUser } from '@/functions/user-management'
+import checkAuth from '@/functions/check-auth'
+// TODO: Extract middleware
 
 // Style imports
 import styles from './Cue.module.scss'
@@ -93,9 +95,10 @@ export default function Cue () {
 }
 
 export async function getServerSideProps (context) {
-  const sessionData = await getSessionData(context)
+  const user = await getUser(context)
+  const authed = await checkAuth({ user })
 
-  if (!sessionData)
+  if (!authed)
     return {
       redirect: {
         destination: '/',
@@ -103,6 +106,7 @@ export async function getServerSideProps (context) {
       }
     }
 
+  const sessionData = user.sessionData
   return {
     props: {
       sessionData


### PR DESCRIPTION
### What
As part of the Cue rearchitecture (#10) / App Router migration, I've decided to migrate the database from MongoDB to Vercel KV for the below reasons.

### Why
As noted in [my last progress update](https://github.com/compsigh/cue/pull/10#issuecomment-1662795124) on #10:
> As if this rearchitecture needed yet another wrench... Mongoose doesn't support the Edge Runtime, since [the MongoDB driver uses the Node.js `net` API](https://mongoosejs.com/docs/nextjs.html), which is [not supported](https://edge-runtime.vercel.app/features/available-apis#unsupported-apis).

I considered two options:
1. Migrate the database over to Vercel KV; or
2. Handle user generation updates off the Edge Runtime, maybe right after a generation is complete right within `/cue`.

That second option didn't sound as appealing, since the `/cue` page is still on Pages Router, and for SoC's sake, handling user generations *in the cue generation API route handler* makes sense to me.

Also, learning new tech lol.

### Potential pitfalls
- Risk is low since as of writing, there are six users on Cue, two of them being me.
  - [ ] Revalidate all invalid Cue invites, just in case.
- Off the top of my head, I think MongoDB has a more generous free tier, but it should be long — if at all — before this becomes a concern.
- This PR doesn't include schema validation, so even though user management is handled centrally, that would be a nice-to-have.

### Plan B
Alternatives to this solution:
- Option 2 as listed above

### Resources
- [Vercel KV docs](https://vercel.com/docs/storage/vercel-kv)