### PR TITLE
Fix invite invalidation

### DIFF
--- a/src/app/api/debug/delete-invite/[inviteCode]/route.js
+++ b/src/app/api/debug/delete-invite/[inviteCode]/route.js
@@ -1,0 +1,11 @@
+import { remove } from '@/functions/invite-management'
+import { NextResponse } from 'next/server'
+
+export async function GET (request, { params }) {
+  if (process.env.NODE_ENV !== 'development')
+    return NextResponse.json({ error: 'This is a dev-mode debug API route.' }, { status: 403 })
+  const inviteCode = params.inviteCode
+  const invite = await remove(inviteCode)
+  if (!invite) return NextResponse.json({ error: 'Invite not found.' }, { status: 404 })
+  return NextResponse.json(invite)
+}

--- a/src/app/api/debug/get-invite/[inviteCode]/route.js
+++ b/src/app/api/debug/get-invite/[inviteCode]/route.js
@@ -1,0 +1,11 @@
+import { fetch } from '@/functions/invite-management'
+import { NextResponse } from 'next/server'
+
+export async function GET (request, { params }) {
+  if (process.env.NODE_ENV !== 'development')
+    return NextResponse.json({ error: 'This is a dev-mode debug API route.' }, { status: 403 })
+  const inviteCode = params.inviteCode
+  const invite = await fetch(inviteCode)
+  if (!invite) return NextResponse.json({ error: 'Invite not found.' }, { status: 404 })
+  return NextResponse.json(invite)
+}

--- a/src/app/api/debug/run-invites/route.js
+++ b/src/app/api/debug/run-invites/route.js
@@ -1,0 +1,32 @@
+import { kv } from '@vercel/kv'
+import { NextResponse } from 'next/server'
+
+export const inviteSchema = {
+  source: '',
+  conditions: [],
+  expires: Intl.DateTimeFormat('en-US', { timeZone: 'America/Los_Angeles' }).format(new Date(new Date().getFullYear() + 1, 0, 1)),
+  valid: true,
+  createdAt: Intl.DateTimeFormat('en-US', { timeZone: 'America/Los_Angeles' }).format(new Date())
+}
+
+async function run () {
+  const invitees = []
+
+  for (const invitee of invitees) {
+    const invite = { ...inviteSchema }
+    invite.source = 'v0.5.0-invites'
+    invite.conditions = ['use-once', 'expires', 'no-invite']
+
+    await kv.hset(`invite:${invitee}`, invite)
+    console.log(`Created invite for ${invitee}`)
+  }
+
+  console.log('Done.')
+}
+
+export async function GET () {
+  if (process.env.NODE_ENV !== 'development')
+    return NextResponse.json({ error: 'This is a dev-mode debug API route.' }, { status: 403 })
+  await run()
+  return NextResponse.json({ success: true })
+}

--- a/src/app/invite/[inviteCode]/page.js
+++ b/src/app/invite/[inviteCode]/page.js
@@ -9,7 +9,9 @@ export default async function Card ({ params }) {
   if (sessionData)
     return redirect('/profile')
 
-  const { inviteCode } = params
+  let { inviteCode } = params
+  inviteCode = inviteCode.replace(/%2B/g, '+')
+  inviteCode = inviteCode.replace(/%40/g, '@')
   const invite = await fetch(inviteCode)
 
   if (!invite)

--- a/src/app/invite/[inviteCode]/page.js
+++ b/src/app/invite/[inviteCode]/page.js
@@ -1,6 +1,6 @@
 import { getSessionData } from '@/functions/user-management'
 import { redirect } from 'next/navigation'
-import { validate } from '@/functions/invite-management'
+import { fetch } from '@/functions/invite-management'
 import SignInButton from '@/components/Button/SignInButton'
 import styles from './Invite.module.scss'
 
@@ -10,7 +10,7 @@ export default async function Card ({ params }) {
     return redirect('/profile')
 
   const { inviteCode } = params
-  const invite = await validate(inviteCode)
+  const invite = await fetch(inviteCode)
 
   if (!invite)
     return (

--- a/src/functions/check-auth.js
+++ b/src/functions/check-auth.js
@@ -15,7 +15,7 @@
 // Can access with auth levels:   1, 2, 3, 4                | 2, 3, 4                | 3, 4                 | 4
 
 import { createUser } from './user-management'
-import { validate } from './invite-management'
+import { fetch, invalidate } from './invite-management'
 
 export const authLevels = {
   'invite-only': 1,
@@ -35,10 +35,12 @@ export default async function checkAuth ({ user, inviteCode }) {
 
   if (currentAuthLevel >= 1)
     if (inviteCode) {
-      const invite = await validate(inviteCode)
+      const invite = await fetch(inviteCode)
       if (invite?.valid) {
         const userProperties = {}
         if (invite.conditions.includes('use-once'))
+          await invalidate(inviteCode)
+        if (invite.conditions.includes('no-invite'))
           userProperties.invitesRemaining = 0
         await createUser(userProperties)
         return true

--- a/src/functions/invite-management.js
+++ b/src/functions/invite-management.js
@@ -10,11 +10,22 @@ export async function getAllCodes () {
   return inviteCodes
 }
 
-export async function validate (inviteCode) {
+export async function fetch (inviteCode) {
   const invite = await kv.hgetall(`invite:${inviteCode}`)
   if (!invite) return null
-  for (const condition of invite.conditions)
-    if (condition === 'use-once')
-      await kv.hset(`invite:${inviteCode}`, 'valid', false)
+  return invite
+}
+
+export async function invalidate (inviteCode) {
+  const invite = await kv.hgetall(`invite:${inviteCode}`)
+  if (!invite) return null
+  await kv.hset(`invite:${inviteCode}`, { valid: false })
+  return invite
+}
+
+export async function remove (inviteCode) {
+  const invite = await kv.hgetall(`invite:${inviteCode}`)
+  if (!invite) return null
+  await kv.del(`invite:${inviteCode}`)
   return invite
 }


### PR DESCRIPTION
Problem was just viewing a `/invite/[inviteCode]` would invalidate it. The `validate` function would check against the invite's conditions, and if `use-once` was present, it would invalidate it automatically. That's been fixed by extracting invalidation out to its own function and calling it separately as part of `checkAuth`.