### PR TITLE
Fix redeem invite login loop

### DIFF
--- a/src/app/invite/[inviteCode]/page.js
+++ b/src/app/invite/[inviteCode]/page.js
@@ -1,12 +1,12 @@
-import { getSessionData } from '@/functions/user-management'
+import { getUserData } from '@/functions/user-management'
 import { redirect } from 'next/navigation'
 import { fetch } from '@/functions/invite-management'
 import SignInButton from '@/components/Button/SignInButton'
 import styles from './Invite.module.scss'
 
 export default async function Card ({ params }) {
-  const sessionData = await getSessionData()
-  if (sessionData)
+  const userData = await getUserData()
+  if (userData)
     return redirect('/profile')
 
   let { inviteCode } = params


### PR DESCRIPTION
Reported by Jonah (thanks!), the issue was: when trying to redeem an invite at the `/invite/<email>` route, it would redirect back to the login screen after signing in with Google.

The root cause was that the `/invite/[inviteCode]` route seeks to redirect those already with an account to `/profile`, but instead of checking against `userData`, it checked against `sessionData`. Furthermore, the `/profile` route redirects those without user data to the login screen (intended behavior).

The problem is now fixed in this PR 🙂