### PR TITLE
Fix no `userData` when rendering user profile

### DIFF
--- a/src/app/profile/page.js
+++ b/src/app/profile/page.js
@@ -13,7 +13,7 @@ import ProfileCard from '@/components/ProfileCard/ProfileCard'
 import Sidebar from '@/components/Sidebar/Sidebar'
 
 export default async function Profile ({ searchParams }) {
-  const user = await getUser()
+  let user = await getUser()
 
   const authRequest = {}
   authRequest.user = user
@@ -25,6 +25,7 @@ export default async function Profile ({ searchParams }) {
   const authed = await checkAuth(authRequest)
   if (!authed)
     redirect('/')
+  user = await getUser()
 
   return (
     <>

--- a/src/functions/check-auth.js
+++ b/src/functions/check-auth.js
@@ -57,12 +57,16 @@ export default async function checkAuth ({ user, inviteCode }) {
 
   if (currentAuthLevel >= 3) {
     const email = user.sessionData.email.toLowerCase()
-    if (email.endsWith('.edu'))
+    if (email.endsWith('.edu')) {
+      await createUser()
       return true
+    }
   }
 
-  if (currentAuthLevel >= 4)
+  if (currentAuthLevel >= 4) {
+    await createUser()
     return true
+  }
 
   return false
 }


### PR DESCRIPTION
Minor UX snag where a first-time user would see an error when visiting the `/profile` route.

This occurred due to rendering the `ProfileCard` component with an outdated `user` object: running `checkAuth` creates a user, so it's appropriate to refresh that before passing it as a prop to the component.

This is now the case 🙂